### PR TITLE
[OBMIN-364] Fixed update of a RefreshToken for users having previous tokens

### DIFF
--- a/src/main/java/space/obminyashka/items_exchange/controller/AuthController.java
+++ b/src/main/java/space/obminyashka/items_exchange/controller/AuthController.java
@@ -70,6 +70,7 @@ public class AuthController {
             authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(username, userLoginDto.getPassword()));
             return ResponseEntity.of(authService.createUserLoginResponseDto(username));
         } catch (AuthenticationException e) {
+            log.warn("[AuthController] An exception occurred while authorization for '{}'", userLoginDto.getUsernameOrEmail(), e);
             throw new BadCredentialsException(getMessageSource(
                     ResponseMessagesHandler.ValidationMessage.INVALID_USERNAME_PASSWORD));
         }

--- a/src/main/java/space/obminyashka/items_exchange/model/RefreshToken.java
+++ b/src/main/java/space/obminyashka/items_exchange/model/RefreshToken.java
@@ -3,6 +3,7 @@ package space.obminyashka.items_exchange.model;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.Accessors;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -26,13 +27,16 @@ public class RefreshToken {
     private User user;
 
     @Column(nullable = false, unique = true)
+    @Accessors(chain = true)
     private String token;
 
     @Column(name = "expiry_date", columnDefinition = "DATE", nullable = false)
+    @Accessors(chain = true)
     private LocalDateTime expiryDate;
 
     @Column(name = "created", columnDefinition = "DATE", nullable = false)
     @CreatedDate
+    @Accessors(chain = true)
     private LocalDateTime created;
 
     public RefreshToken(User user, String token, LocalDateTime expiryDate) {

--- a/src/main/java/space/obminyashka/items_exchange/model/User.java
+++ b/src/main/java/space/obminyashka/items_exchange/model/User.java
@@ -21,6 +21,7 @@ import java.util.*;
 public class User extends BaseEntity implements UserDetails {
 
     @Column(unique = true)
+    @Accessors(chain = true)
     private String username;
     private String password;
     @Column(unique = true)
@@ -87,6 +88,7 @@ public class User extends BaseEntity implements UserDetails {
     private List<User> blacklistedUsers;
 
     @OneToOne(mappedBy = "user")
+    @Accessors(chain = true)
     private RefreshToken refreshToken;
 
     @OneToOne(mappedBy = "user", cascade = CascadeType.DETACH)

--- a/src/main/java/space/obminyashka/items_exchange/service/JwtTokenService.java
+++ b/src/main/java/space/obminyashka/items_exchange/service/JwtTokenService.java
@@ -87,7 +87,10 @@ public class JwtTokenService implements OAuth2TokenValidator<Jwt> {
     }
 
     public LocalDateTime getAccessTokenExpiration(String accessToken) {
-        return tokenDecoder.decode(accessToken).getExpiresAt().atZone(ZoneId.of("Europe/Kiev")).toLocalDateTime();
+        return Optional.ofNullable(tokenDecoder.decode(accessToken).getExpiresAt())
+                .map(instant -> instant.atZone(ZoneId.of("Europe/Kiev")))
+                .map(ZonedDateTime::toLocalDateTime)
+                .orElse(LocalDateTime.now());
     }
 
     public String getRefreshTokenExpiration(ZonedDateTime zonedDateTime) {

--- a/src/main/java/space/obminyashka/items_exchange/service/impl/RefreshTokenServiceImpl.java
+++ b/src/main/java/space/obminyashka/items_exchange/service/impl/RefreshTokenServiceImpl.java
@@ -1,5 +1,6 @@
 package space.obminyashka.items_exchange.service.impl;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import space.obminyashka.items_exchange.dao.RefreshTokenRepository;
@@ -8,7 +9,6 @@ import space.obminyashka.items_exchange.model.User;
 import space.obminyashka.items_exchange.service.JwtTokenService;
 import space.obminyashka.items_exchange.service.RefreshTokenService;
 
-import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -22,9 +22,13 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
 
     @Override
     public RefreshToken createRefreshToken(User user) {
-        final var refreshToken = jwtTokenService.generateRefreshToken(user.getUsername());
+        final String token = jwtTokenService.generateRefreshToken(user.getUsername());
         final var tokenExpirationTime = jwtTokenService.generateRefreshTokenExpirationTime();
-        return refreshTokenRepository.save(new RefreshToken(user, refreshToken, tokenExpirationTime));
+        return refreshTokenRepository.save(Optional.ofNullable(user.getRefreshToken())
+                .map(refreshToken -> refreshToken.setToken(token)
+                        .setCreated(LocalDateTime.now())
+                        .setExpiryDate(tokenExpirationTime))
+                .orElseGet(() -> new RefreshToken(user, token, tokenExpirationTime)));
     }
 
     private boolean isRefreshTokenExpired(RefreshToken refreshToken) {

--- a/src/test/java/space/obminyashka/items_exchange/service/RefreshTokenServiceTest.java
+++ b/src/test/java/space/obminyashka/items_exchange/service/RefreshTokenServiceTest.java
@@ -1,0 +1,55 @@
+package space.obminyashka.items_exchange.service;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import space.obminyashka.items_exchange.dao.RefreshTokenRepository;
+import space.obminyashka.items_exchange.model.RefreshToken;
+import space.obminyashka.items_exchange.model.User;
+import space.obminyashka.items_exchange.service.impl.RefreshTokenServiceImpl;
+
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenServiceTest {
+    @Mock
+    private JwtTokenService jwtTokenService;
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+    @InjectMocks
+    private RefreshTokenServiceImpl refreshTokenService;
+
+    @ParameterizedTest
+    @MethodSource("testUsersWithRefreshTokens")
+    void createRefreshToken_shouldCreateOrUpdateToken(User testUser) {
+        when(jwtTokenService.generateRefreshToken(anyString())).thenReturn("token_string");
+        when(jwtTokenService.generateRefreshTokenExpirationTime()).thenReturn(LocalDateTime.MAX);
+        when(refreshTokenRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        final var refreshToken = refreshTokenService.createRefreshToken(testUser);
+
+        assertAll(
+                () -> assertNotNull(refreshToken),
+                () -> assertNotNull(refreshToken.getToken()),
+                () -> assertNotNull(refreshToken.getExpiryDate()),
+                () -> verify(refreshTokenRepository).save(refreshToken)
+        );
+    }
+
+    private static Stream<User> testUsersWithRefreshTokens() {
+        return Stream.of(
+                new User().setUsername("user_without_token"),
+                new User().setUsername("user_with_token").setRefreshToken(new RefreshToken()));
+    }
+}


### PR DESCRIPTION
The problem was related to hibernate which created a new token instead of merging the data with the current one. 
Fix: split those logic